### PR TITLE
Replace 'context' with 'code'

### DIFF
--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -125,7 +125,7 @@ class misc(commands.Cog):
     async def run(self, ctx, lang: str, *, code: str):
         '''Run code and get the output'''
         if len(code) > 200:
-            await ctx.send('Context too long')
+            await ctx.send('Code too long')
         else:
             try:
                 r = await self.bot.session.post("https://emkc.org/api/v1/piston/execute", json={"language": lang, "source": code})


### PR DESCRIPTION
As the code is not technically "context" and that won't make sense to people who don't know dpy well, I believe it should be changed to 'code', as that is what it technically is.